### PR TITLE
Bump sharp version to fix Node 12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "promise-retry": "^1.1.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "sharp": "^0.22.0",
+    "sharp": "^0.23.0",
     "tmp": "0.0.33",
     "tmp-promise": "^1.0.5",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "promise-retry": "^1.1.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "sharp": "^0.23.0",
+    "sharp": "^0.24.0",
     "tmp": "0.0.33",
     "tmp-promise": "^1.0.5",
     "uuid": "^3.3.2"


### PR DESCRIPTION
see
https://sharp.pixelplumbing.com/en/stable/changelog/#v0221-25th-april-2019

fixes https://github.com/gsuitedevs/md2googleslides/issues/54